### PR TITLE
feat: Enhance MCP tool to return full event details

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,19 @@ A command-line tool and MCP server for interacting with Google Calendar.
 
 ## Installation
 
-To build the tool from source, you need to have Go installed. Then run the following commands:
+You will need to have Go installed on your system.
+
+### Using `go install`
+
+Once the repository is public, you can install the `calctl` command directly:
+```bash
+go install github.com/ghchinoy/calctl@latest
+```
+Make sure that your Go `bin` directory is in your system's `PATH`. This is typically `$HOME/go/bin`.
+
+### From Source
+
+To build the tool from source, you can clone the repository and build it manually:
 
 ```bash
 git clone https://github.com/ghchinoy/calctl

--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ You can also run `calctl` as an MCP server to expose its functionality as tools.
 
 The following tools are available:
 
-*   `get_weekly_calendar(current_date: str)`: Get the user's calendar events for the week of the given date (YYYY-MM-DD). If the date is omitted, it uses the current week.
+*   `get_weekly_calendar(current_date: str)`: Get the user's calendar events for the week of the given date (YYYY-MM-DD). If the date is omitted, it uses the current week. This tool returns a JSON object containing a list of full event resources, including all details for each event.
 *   `get_event_details(event_id: str)`: Get the details of a specific event by its ID.

--- a/internal/calendar/calendar.go
+++ b/internal/calendar/calendar.go
@@ -30,7 +30,7 @@ func GetWeeklyEvents(srv *calendar.Service, dateStr string) (*calendar.Events, e
 	tMax := endOfWeek.Format(time.RFC3339)
 
 	events, err := srv.Events.List("primary").ShowDeleted(false).
-		SingleEvents(true).TimeMin(tMin).TimeMax(tMax).OrderBy("startTime").Do()
+		SingleEvents(true).TimeMin(tMin).TimeMax(tMax).OrderBy("startTime").Fields("*").Do()
 	if err != nil {
 		return nil, fmt.Errorf("unable to retrieve events for the week: %v", err)
 	}

--- a/mcp/server.go
+++ b/mcp/server.go
@@ -2,12 +2,12 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/ghchinoy/calctl/internal/auth"
 	"github.com/ghchinoy/calctl/internal/calendar"
@@ -110,31 +110,22 @@ func getWeeklyCalendarHandler(ctx context.Context, ss *mcp.ServerSession, params
 		return nil, err
 	}
 
-	var output string
 	if len(events.Items) == 0 {
-		output = "No upcoming events found for this week."
-	} else {
-		output = "Events for this week:\n"
-		for _, item := range events.Items {
-			date := item.Start.DateTime
-			if date == "" {
-				date = item.Start.Date
-			}
-			t, err := time.Parse(time.RFC3339, date)
-			if err != nil {
-				t, err = time.Parse("2006-01-02", date)
-				if err != nil {
-					output += fmt.Sprintf("- %s (Unable to parse date: %s)\n", item.Summary, date)
-					continue
-				}
-			}
-			output += fmt.Sprintf("- %s (%s) [%s]\n", item.Summary, t.Format("Mon, Jan 2 3:04 PM"), item.Id)
-		}
+		return &mcp.CallToolResultFor[any]{
+			Content: []mcp.Content{
+				&mcp.TextContent{Text: "No upcoming events found for this week."},
+			},
+		}, nil
+	}
+
+	jsonResult, err := json.MarshalIndent(events.Items, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal events to JSON: %w", err)
 	}
 
 	return &mcp.CallToolResultFor[any]{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: output},
+			&mcp.TextContent{Text: string(jsonResult)},
 		},
 	}, nil
 }


### PR DESCRIPTION
The `get_weekly_calendar` MCP tool has been updated to return a JSON object containing a list of full event resources. This provides a much richer data source for programmatic consumers.

- The internal `GetWeeklyEvents` function now fetches all available fields for each event.
- The `getWeeklyCalendarHandler` in the MCP server now marshals the full event list to JSON.
- The `README.md` has been updated to reflect this new behavior.